### PR TITLE
add contributions import to fix error

### DIFF
--- a/basxconnect_demo/settings/base.py
+++ b/basxconnect_demo/settings/base.py
@@ -26,6 +26,7 @@ INSTALLED_APPS = (
     [
         "basxconnect.core.apps.CoreConfig",
         "django.contrib.admin",
+        "basxconnect.contributions.apps.ContributionsConfig",
         "bread.contrib.reports.apps.ReportsConfig",
     ]
     + BREAD_DEPENDENCIES


### PR DESCRIPTION
RuntimeError: Model class basxconnect.contributions.models.ContributionImport doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.